### PR TITLE
Changed type of `trello_card_url` from fixed length string to textfield.

### DIFF
--- a/app/models/issue.py
+++ b/app/models/issue.py
@@ -28,7 +28,7 @@ class Issue(db.Model):
     url = db.Column(db.Text(), unique=True)
     timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow)
     github_issue_id = db.Column(db.Integer, unique=True)
-    trello_card_url = db.Column(db.String(64), unique=True)
+    trello_card_url = db.Column(db.Text(), unique=True)
     trello_card_id = db.Column(db.String(64), unique=True)
 
     # Associations

--- a/app/models/pull_request.py
+++ b/app/models/pull_request.py
@@ -28,7 +28,7 @@ class PullRequest(db.Model):
     url = db.Column(db.Text(), unique=True)
     timestamp = db.Column(db.DateTime, index=True, default=datetime.utcnow)
     github_pull_request_id = db.Column(db.Integer, unique=True)
-    trello_card_url = db.Column(db.String(64), unique=True)
+    trello_card_url = db.Column(db.Text(), unique=True)
     trello_card_id = db.Column(db.String(64), unique=True)
 
     # Associations

--- a/migrations/versions/3b6e7f250153_update_trello_url_type.py
+++ b/migrations/versions/3b6e7f250153_update_trello_url_type.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""Update trello_url type.
+
+Revision ID: 3b6e7f250153
+Revises: 0afe19626b22
+Create Date: 2018-03-30 16:41:29.076091
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '3b6e7f250153'
+down_revision = '0afe19626b22'
+
+
+def upgrade():
+    op.alter_column(
+        'issues', 'trello_card_url',
+        existing_type=sa.String(length=64),
+        type_=sa.Text(),
+        existing_nullable=True
+    )
+    op.alter_column(
+        'pull_requests', 'trello_card_url',
+        existing_type=sa.String(length=64),
+        type_=sa.Text(),
+        existing_nullable=True
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'pull_requests', 'trello_card_url',
+        existing_type=sa.Text(),
+        type_=sa.String(length=64),
+        existing_nullable=True
+    )
+    op.alter_column(
+        'issues', 'trello_card_url',
+        existing_type=sa.Text(),
+        type_=sa.String(length=64),
+        existing_nullable=True
+    )


### PR DESCRIPTION
### What does this PR do?
Changes the type of `trello_card_url` from fixed-size 64 character length, to variable length textfield.

### Motivation
Length of `trello_card_url` was sometimes longer than 64 characters.