### PR TITLE
Updated data for `Subscription` and `SubscribedList` models and forms.

### DIFF
--- a/app/models/subscribed_list.py
+++ b/app/models/subscribed_list.py
@@ -40,3 +40,15 @@ class SubscribedList(db.Model):
         ), {}
     )
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    # Associations
+    list = db.relationship(
+        'List',
+        backref=db.backref('list_subscribed_list', lazy='joined'),
+        lazy='joined'
+    )
+    subscription = db.relationship(
+        'Subscription',
+        backref=db.backref('subscription_subscribed_list', lazy='joined'),
+        lazy='joined'
+    )

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -47,3 +47,13 @@ class Subscription(db.Model):
         lazy='dynamic',
         cascade='all, delete-orphan'
     )
+    board = db.relationship(
+        'Board',
+        backref=db.backref('subscription_board', lazy='joined'),
+        lazy='joined'
+    )
+    repo = db.relationship(
+        'Repo',
+        backref=db.backref('subscription_repo', lazy='joined'),
+        lazy='joined'
+    )

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,8 +28,24 @@
     </div>
     {% endif %}
 
-    <div class="page-header">
-      <h1>{{ organization_name }}'s Subscriptions</h1>
+    <div class="repo-tabs">
+      <ul class="nav nav-tabs">
+        <li>
+          <a href="{{ url_for('board.index') }}">Boards</a>
+        </li>
+        <li>
+          <a href="{{ url_for('github_member.index') }}">GitHub Members</a>
+        </li>
+        <li>
+          <a href="{{ url_for('trello_member.index') }}">Trello Members</a>
+        </li>
+        <li>
+          <a href="{{ url_for('repo.index') }}">Repos</a>
+        </li>
+        <li>
+          <a href="{{ url_for('subscription.index') }}">Subscriptions</a>
+        </li>
+      </ul>
     </div>
   {% else %}
     <div class="page-header">

--- a/app/templates/subscribed_lists.html
+++ b/app/templates/subscribed_lists.html
@@ -16,15 +16,15 @@
 
 {% block page_content %}
   <div class="page-header">
-    <h1>Subscribed Lists for <b>{{ subscription.board_id }}, {{ subscription.repo_id }}</b></h1>
+    <h1>Subscribed Lists for <b>{{ subscription.repo.name }} | {{ subscription.board.name }}</b></h1>
   </div>
 
   <table class="table table-hover trello-lists">
     <thead>
       <tr>
-        <th>Subscription Board ID</th>
-        <th>Subscription Repo ID</th>
-        <th>Subscription List ID</th>
+        <th>Repository Name</th>
+        <th>Board Name</th>
+        <th>List Name</th>
         <th>Member ID</th>
         <th>Delete</th>
       </tr>
@@ -32,9 +32,9 @@
 
     {% for subscribed_list, form in list_form_pairs %}
       <tr>
-        <td>{{ subscribed_list.subscription_board_id }}</td>
-        <td>{{ subscribed_list.subscription_repo_id }}</td>
-        <td>{{ subscribed_list.list_id }}</td>
+        <td>{{ subscribed_list.subscription.repo.name }}</td>
+        <td>{{ subscribed_list.subscription.board.name }}</td>
+        <td>{{ subscribed_list.list.name }}</td>
         <td>{{ subscribed_list.trello_member_id }}</td>
 
         <form method="POST" action="{{ url_for('.delete', board_id=subscription.board_id, repo_id=subscription.repo_id, list_id=subscribed_list.list_id) }}">

--- a/app/templates/subscriptions.html
+++ b/app/templates/subscriptions.html
@@ -22,8 +22,8 @@
   <table class="table table-hover subscriptions">
     <thead>
       <tr>
-        <th>Board ID</th>
-        <th>Repository ID</th>
+        <th>Board Name</th>
+        <th>Repository Name</th>
         <th>Subscribed Lists</th>
         <th>Issue Autocard</th>
         <th>Pull Request Autocard</th>
@@ -34,8 +34,8 @@
 
     {% for subscription, update_form, delete_form in subscription_forms_tuples %}
       <tr>
-        <td>{{ subscription.board_id }}</td>
-        <td>{{ subscription.repo_id }}</td>
+        <td>{{ subscription.board.name }}</td>
+        <td>{{ subscription.repo.name }}</td>
         <td>
           <a href="{{ url_for('subscribed_list.index', board_id=subscription.board_id, repo_id=subscription.repo_id) }}">
           {{ subscription.subscribed_lists.count() }} lists


### PR DESCRIPTION
### What does this PR do?
- Uses human-readable names instead of ids in forms for `Subscription` and `SubscribedList` views