### PR TITLE
Only delete the reference to open issues / pull requests in Gello. Don't delete the actual trello card.

### DIFF
--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -18,7 +18,7 @@ Task-specific initialization code.
 from .. import celery
 
 from .github_base_task import GitHubBaseTask
-from .delete_trello_card import DeleteTrelloCard
+from .delete_trello_card import DeleteCardObjectFromDatabase
 from .create_github_webhook import CreateGitHubWebhook
 from .create_trello_card import CreateTrelloCard
 from .create_issue_card import CreateIssueCard
@@ -30,7 +30,7 @@ from .github_receiver import GitHubReceiver
 def _register_tasks():
     """Registers class based celery tasks with celery worker"""
     celery.tasks.register(GitHubBaseTask())
-    celery.tasks.register(DeleteTrelloCard())
+    celery.tasks.register(DeleteCardObjectFromDatabase())
     celery.tasks.register(CreateTrelloCard())
     celery.tasks.register(CreateIssueCard())
     celery.tasks.register(CreateManualCard())

--- a/app/tasks/delete_trello_card.py
+++ b/app/tasks/delete_trello_card.py
@@ -19,8 +19,8 @@ from . import GitHubBaseTask
 from ..services import IssueService, PullRequestService, TrelloService
 
 
-class DeleteTrelloCard(GitHubBaseTask):
-    """A class that deletes a trello card on a board."""
+class DeleteCardObjectFromDatabase(GitHubBaseTask):
+    """A class that deletes a trello card object within Gello."""
 
     def __init__(self):
         """Initializes a task to create a manual trello card."""
@@ -29,10 +29,11 @@ class DeleteTrelloCard(GitHubBaseTask):
         self._trello_service = TrelloService()
 
     def run(self, scope, github_id, card_id):
-        """Deletes a trello card on a trello board."""
-        self._trello_service.delete_card(card_id=card_id)
+        """Deletes the record of the trello card in Gello.
 
-        # Deletes the card record in the database
+        NOTE: this does not delete the card on the Trello board, only removes
+        the record from the database in Gello.
+        """
         if scope == 'issue':
             self._issue_service.delete(github_issue_id=github_id)
         elif scope == 'pull_request':


### PR DESCRIPTION
### What does this PR do?
- Delete the reference to open issues / pull requests from Gello, but doesn't delete the card on corresponding the Trello boards

<img width="1440" alt="screen shot 2018-04-06 at 1 07 57 pm" src="https://user-images.githubusercontent.com/8942499/38434225-a14ef704-399b-11e8-9373-5460dcc153b4.png">
