### PR TITLE
Added `APM_ENABLED` option to configure Datadog tracing in Gello.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -42,6 +42,7 @@ gunicorn = "*"
 "psycopg2" = "*"
 pygithub = "*"
 py-trello = "*"
+ddtrace = "*"
 
 [dev-packages]
 mock = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fae35ed5f6ecc47a20a872f8ffe6c58415a9f072e7db58ada3c8c02ebd465b54"
+            "sha256": "a5a300465142c421e184d2bb8e755046ff9dc3b8d90176d83df8faade75d0be6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -70,10 +70,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
@@ -88,6 +88,13 @@
                 "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
             ],
             "version": "==6.7"
+        },
+        "ddtrace": {
+            "hashes": [
+                "sha256:7b0526f204a4bf7bdf221f2b1b7fd51737e7426635aa545ee471883d4c0891b3"
+            ],
+            "index": "pypi",
+            "version": "==0.11.1"
         },
         "dominate": {
             "hashes": [
@@ -247,6 +254,12 @@
             "index": "pypi",
             "version": "==1.0"
         },
+        "msgpack-python": {
+            "hashes": [
+                "sha256:378cc8a6d3545b532dfd149da715abae4fda2a3adb6d74e525d0d5e51f46909b"
+            ],
+            "version": "==0.5.6"
+        },
         "oauthlib": {
             "hashes": [
                 "sha256:09d438bcac8f004ae348e721e9d8a7792a9e23cd574634e973173344046287f5",
@@ -329,10 +342,10 @@
         },
         "pygithub": {
             "hashes": [
-                "sha256:1ed08f775ec5067bc8452b72bde2dbb95cf4e52ff2bd50cc32c69c91ffad9272"
+                "sha256:8a87bc0fbd0b70c2f12911f7f25a493cd13371bc1bbac6c548cc61b69e7d006f"
             ],
             "index": "pypi",
-            "version": "==1.38"
+            "version": "==1.39"
         },
         "pyjwt": {
             "hashes": [
@@ -356,18 +369,11 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
-                "sha256:3a47ff71597f821cd84a162e71593004286e5be07a340fd462f0d33a760782b5",
-                "sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0",
-                "sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d",
-                "sha256:61242a9abc626379574a166dc0e96a66cd7c3b27fc10868003fa210be4bff1c9",
-                "sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef",
-                "sha256:ba18e6a243b3625513d85239b3e49055a2f0318466e0b8a92b8fb8ca7ccdf55f",
-                "sha256:ed6509d9af298b7995d69a440e2822288f2eca1681b8cce37673dbb10091e5fe",
-                "sha256:f93ddcdd6342f94cea379c73cddb5724e0d6d0a1c91c9bdef364dc0368ba4fda"
+                "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555",
+                "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
             ],
             "index": "pypi",
-            "version": "==2018.3"
+            "version": "==2018.4"
         },
         "redis": {
             "hashes": [
@@ -401,10 +407,10 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:249000654107a420a40200f1e0b555a79dfd4eff235b2ff60bc77714bd045f2d"
+                "sha256:7cb00cc9b9f92ef8b4391c8a2051f81eeafefe32d63c6b395fd51401e9a39edb"
             ],
             "index": "pypi",
-            "version": "==1.2.5"
+            "version": "==1.2.6"
         },
         "urllib3": {
             "hashes": [
@@ -441,6 +447,12 @@
             "index": "pypi",
             "version": "==0.14.1"
         },
+        "wrapt": {
+            "hashes": [
+                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
+            ],
+            "version": "==1.10.11"
+        },
         "wtforms": {
             "hashes": [
                 "sha256:ffdf10bd1fa565b8233380cb77a304cd36fd55c73023e91d4b803c96bc11d46f"
@@ -460,10 +472,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:8b9a7c3704657cb0831b3ded0a6b61377947c8235b76649bb7de4bfe2e6cfa56",
-                "sha256:cf66675e22ae91a4f20e4b8354f117d3e3d1de651513051d109cc39645fb3672"
+                "sha256:4e8a0ed6a8705a26768f4c3da26026013b157821fe5f95881599556ea9d91c19",
+                "sha256:dae4aaa78eafcad10ce2581fc34d694faa616727837fd8e55c1a00951ad6744f"
             ],
-            "version": "==4.0.0"
+            "version": "==4.0.2"
         },
         "six": {
             "hashes": [

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -101,3 +101,22 @@ def create_app(config_name):
 
 
 app = create_app(os.getenv('FLASK_CONFIG') or 'default')
+
+# Configure tracing if `APM_ENABLED` is `True`
+if app.config.get('APM_ENABLED'):
+    from ddtrace import tracer, patch
+    from ddtrace.contrib.flask import TraceMiddleware
+
+    # Required for Flask middleware:
+    #   http://pypi.datadoghq.com/trace/docs/#module-ddtrace.contrib.flask
+    import blinker as _
+
+    patch(celery=True)
+    patch(sqlalchemy=True)
+
+    traced_app = TraceMiddleware(
+        app,
+        tracer,
+        service='gello',
+        distributed_tracing=False
+    )

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ import os
 
 
 class Config:
+    APM_ENABLED = 'APM_ENABLED' in os.environ
     BROKER_POOL_LIMIT = 0
     CELERY_BROKER_URL = os.environ.get('REDIS_URL') or \
         'redis://localhost:6379/0'


### PR DESCRIPTION
### What does this PR do?
Adds a boolean flag `APM_ENABLED` which defaults to `False`, which may be set to `True` if the user wishes to trace Gello with the Datadog APM.