### PR TITLE
Add support for merged PR autocreate card

### DIFF
--- a/app/controllers/main/views.py
+++ b/app/controllers/main/views.py
@@ -46,7 +46,8 @@ def index():
             s,
             UpdateForm(
                 issue_autocard=s.issue_autocard,
-                pull_request_autocard=s.pull_request_autocard
+                pull_request_autocard=s.pull_request_autocard,
+                merged_pull_request_autocard=s.merged_pull_request_autocard
             ),
             DeleteForm()
         ) for s in subscriptions

--- a/app/controllers/subscriptions/forms.py
+++ b/app/controllers/subscriptions/forms.py
@@ -77,6 +77,16 @@ class NewSubscriptionForm(FlaskForm):
             """
         )
     )
+    merged_pull_request_autocard = BooleanField(
+        'Merged Pull Request Autocard',
+        description=textwrap.dedent(
+            """
+            If checked, trello cards will automatically be created when a
+            <a href='https://help.github.com/articles/about-pull-requests/'>Pull Request</a>
+            by any auther, including those in your organization, is merged.  
+            """
+        )
+    )
     submit = SubmitField('Create')
 
     def validate(self):
@@ -165,6 +175,7 @@ class UpdateForm(FlaskForm):
     """Form for updating an existing subscription."""
     issue_autocard = BooleanField('Issue Autocard')
     pull_request_autocard = BooleanField('Pull Request Autocard')
+    merged_pull_request_autocard = BooleanField('Merged Pull Request Autocard')
     submit = SubmitField('Update')
 
 

--- a/app/controllers/subscriptions/forms.py
+++ b/app/controllers/subscriptions/forms.py
@@ -83,7 +83,7 @@ class NewSubscriptionForm(FlaskForm):
             """
             If checked, trello cards will automatically be created when a
             <a href='https://help.github.com/articles/about-pull-requests/'>Pull Request</a>
-            by any auther, including those in your organization, is merged.  
+            by any author, including those in your organization, is merged.  
             """
         )
     )

--- a/app/controllers/subscriptions/views.py
+++ b/app/controllers/subscriptions/views.py
@@ -42,6 +42,7 @@ def create():
             repo_id=create_form.get_repo_id(),
             issue_autocard=create_form.issue_autocard.data,
             pull_request_autocard=create_form.pull_request_autocard.data,
+            merged_pull_request_autocard=create_form.merged_pull_request_autocard,
             list_ids=list_ids
         )
 
@@ -74,7 +75,8 @@ def update(board_id, repo_id):
         board_id=board_id,
         repo_id=repo_id,
         issue_autocard=form.issue_autocard.data,
-        pull_request_autocard=form.pull_request_autocard.data
+        pull_request_autocard=form.pull_request_autocard.data,
+        merged_pull_request_autocard=form.merged_pull_request_autocard
     )
     flash('Updated subscription')
 

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -34,6 +34,7 @@ class Subscription(db.Model):
     )
     issue_autocard = db.Column(db.Boolean, default=True)
     pull_request_autocard = db.Column(db.Boolean, default=True)
+    merged_pull_request_autocard = db.Column(db.Boolean, default=True)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     # Associations

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -32,7 +32,7 @@ class SubscriptionService(CRUDService):
         self._subscribed_list_service = SubscribedListService()
 
     def create(self, board_id, repo_id, issue_autocard, pull_request_autocard,
-               list_ids=[]):
+               merged_pull_request_autocard, list_ids=[]):
         """Creates and persists a new subscription record to the database.
 
         Args:
@@ -43,6 +43,8 @@ class SubscriptionService(CRUDService):
                 created.
             pull_request_autocard (Boolean): If `autocard` is `true` for Pull
                 Requests created.
+            merged_pull_request_autocard (Boolean): If 'autocard' is true for Merged
+                Pull Requests
             list_ids (list(str)): An optional list of ids for trello lists to
                 associate to the subscription as `SubscribedList`s.
 
@@ -53,7 +55,8 @@ class SubscriptionService(CRUDService):
             board_id=board_id,
             repo_id=repo_id,
             issue_autocard=issue_autocard,
-            pull_request_autocard=pull_request_autocard
+            pull_request_autocard=pull_request_autocard,
+            merged_pull_request_autocard=merged_pull_request_autocard
         )
         db.session.add(subscription)
 
@@ -68,7 +71,7 @@ class SubscriptionService(CRUDService):
         # Persists the subscription
         db.session.commit()
 
-    def update(self, board_id, repo_id, issue_autocard, pull_request_autocard):
+    def update(self, board_id, repo_id, issue_autocard, pull_request_autocard, merged_pull_request_autocard):
         """Updates a persisted subscription's autocard value.
 
         Args:
@@ -79,6 +82,8 @@ class SubscriptionService(CRUDService):
                 created.
             pull_request_autocard (Boolean): If `autocard` is `true` for Pull
                 Requests created.
+            merged_pull_request_autocard (Boolean): If `autocard` is `true` for 
+                 Merged Pull Requests
 
         Returns:
             None
@@ -86,6 +91,7 @@ class SubscriptionService(CRUDService):
         subscription = Subscription.query.get([board_id, repo_id])
         subscription.issue_autocard = issue_autocard
         subscription.pull_request_autocard = pull_request_autocard
+        subscription.merged_pull_request_autocard = merged_pull_request_autocard
 
         # Persist the changes
         db.session.commit()

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -23,6 +23,7 @@ from .create_github_webhook import CreateGitHubWebhook
 from .create_trello_card import CreateTrelloCard
 from .create_issue_card import CreateIssueCard
 from .create_pull_request_card import CreatePullRequestCard
+from .create_merged_pull_request_card import CreateMergedPullRequestCard
 from .create_manual_card import CreateManualCard
 from .github_receiver import GitHubReceiver
 
@@ -35,6 +36,7 @@ def _register_tasks():
     celery.tasks.register(CreateIssueCard())
     celery.tasks.register(CreateManualCard())
     celery.tasks.register(CreatePullRequestCard())
+    celery.tasks.register(CreateMergedPullRequestCard())
     celery.tasks.register(CreateGitHubWebhook())
     celery.tasks.register(GitHubReceiver())
 

--- a/app/tasks/create_merged_pull_request_card.py
+++ b/app/tasks/create_merged_pull_request_card.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""create_pull_request_card.py
+
+Creates a trello card based on GitHub pull request data.
+"""
+
+import textwrap
+from . import CreateTrelloCard
+from ..services import PullRequestService
+
+
+class CreateMergedPullRequestCard(CreateTrelloCard):
+    """A class that creates a trello card on a board."""
+
+    def __init__(self):
+        """Initializes a task to create a merged pull request trello card."""
+        super().__init__()
+        self._pull_request_service = PullRequestService()
+
+    def _card_body(self):
+        """Concrete helper method.
+
+        Internal helper to format the trello card body, based on the data
+        passed in.
+
+        Returns:
+            str: the markdown template for the Trello card created.
+        """
+        return textwrap.dedent(
+            f"""
+            # GitHub Pull Request Merged
+            ___
+            - Pull Request link: [{self._title}]({self._url})
+            - Opened by: [{self._user}]({self._user_url})
+            ___
+            ### Pull Request Body
+            ___
+            """
+        ) + self._body
+
+    def _persist_card_to_database(self, card):
+        """Concrete helper method.
+
+        Internal helper to save the record created to the database.
+
+        Args:
+            card (trello.Card): An object representing the trello card created.
+
+        Returns:
+            None
+        """
+        self._pull_request_service.create(
+            name=self._title,
+            url=self._url,
+            github_pull_request_id=self._id,
+            repo_id=self._repo_id,
+            trello_board_id=card.board_id,
+            trello_card_id=card.id,
+            trello_card_url=card.url
+        )

--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -115,7 +115,7 @@ class GitHubReceiver(GitHubBaseTask):
              action == 'opened':
             self._create_trello_pull_request_card(board_id, list_id, assignee_id)
         elif merged_pull_request_autocard and merged and action == 'closed':
-            self._create_trello_merged_pull_request_card(board_id, list_id, _assignee_id)
+            self._create_trello_merged_pull_request_card(board_id, list_id, assignee_id)
         elif scope == 'issue' and action == 'closed':
             self._delete_issue_trello_card_objects()
         elif scope == 'pull_request' and action == 'closed' and not merged_pull_request_autocard:

--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -75,7 +75,7 @@ class GitHubReceiver(GitHubBaseTask):
                     list_id=trello_list.list_id,
                     issue_autocard=subscription.issue_autocard,
                     pull_request_autocard=subscription.pull_request_autocard,
-                    merged_pull_request_autocard=subscription.pr_closed_autocard
+                    merged_pull_request_autocard=subscription.pr_closed_autocard,
                     assignee_id=trello_list.trello_member_id
                 )
 

--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -115,7 +115,7 @@ class GitHubReceiver(GitHubBaseTask):
              action == 'opened':
             self._create_trello_pull_request_card(board_id, list_id, assignee_id)
         elif merged_pull_request_autocard and merged and action == 'closed':
-            self._create_trello_merged_pull_request_card()
+            self._create_trello_merged_pull_request_card(board_id, list_id, _assignee_id)
         elif scope == 'issue' and action == 'closed':
             self._delete_issue_trello_card_objects()
         elif scope == 'pull_request' and action == 'closed' and not merged_pull_request_autocard:

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,6 +31,8 @@
           <th>Autocard</th>
           <th>Pull Requests</th>
           <th>Autocard</th>
+          <th>Merged Pull Requests</th>
+          <th>Autocard</th>
           <th>Update</th>
           <th>Delete</th>
         </tr>
@@ -66,6 +68,11 @@
               </a>
             </td>
             <td>{{ update_form.pull_request_autocard(checked=subscription.pull_request_autocard) }}</td>
+            <td>{{ update_form.submit(class="btn btn-primary") }}</td>
+            <td>
+              <p>NA</p>
+            </td>
+            <td>{{ update_form.merged_pull_request_autocard(checked=subscription.merged_pull_request_autocard) }}</td>
             <td>{{ update_form.submit(class="btn btn-primary") }}</td>
           </form>
           <form method="POST" action="{{ url_for('subscription.delete', board_id=subscription.board_id, repo_id=subscription.repo_id) }}">

--- a/migrations/versions/0afe19626b22_update_autocard_for_issues_and_pull_.py
+++ b/migrations/versions/0afe19626b22_update_autocard_for_issues_and_pull_.py
@@ -84,6 +84,16 @@ def upgrade():
         )
     )
 
+    op.add_column(
+        'subscriptions',
+        sa.Column(
+            'merged_pull_request_autocard',
+            sa.Boolean(),
+            nullable=False,
+            server_default='false'
+        )
+    )
+
     for sub in session.query(Subscription).filter_by(issue_autocard=True):
         sub.pull_request_autocard = True
 

--- a/tests/utils/database.py
+++ b/tests/utils/database.py
@@ -55,14 +55,15 @@ def create_list():
     )
 
 
-def create_subscription(issue_autocard=True, pull_request_autocard=True):
+def create_subscription(issue_autocard=True, pull_request_autocard=True, merged_pull_request_autocard=True):
     """Create a subscription."""
     db.session.add(
         Subscription(
             board_id=default_board_id,
             repo_id=default_repo_id,
             issue_autocard=issue_autocard,
-            pull_request_autocard=pull_request_autocard
+            pull_request_autocard=pull_request_autocard,
+            merged_pull_request_autocard=merged_pull_request_autocard
         )
     )
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Gello Contribution Guidelines if you have not yet done so.* -->

### What does this PR do?

This PR adds a new subscription model that allows a user to auto create a trello card when a PR is merged. 

### Motivation

We (on the integrations team) have a use case for creating a card on our trello board when a PR is merged so release steps can be taken for that specific integration. 

### Additional Notes
Right now this is set to happen when any PR is merged, not only ones that were created by community members but also those that were made by members of the github organization. 