### PR TITLE
Fixed Integrity Error by deleting records of lists before deleting their parent boards

### DIFF
--- a/app/services/board_service.py
+++ b/app/services/board_service.py
@@ -84,6 +84,12 @@ class BoardService(APIService):
                 # Add the new lists to the database for a given board
                 self._create_lists(trello_lists, trello_board.id)
             else:
+                # Delete the lists that reference this board first
+                persisted_lists = List.query.filter_by(board_id=record.trello_board_id)
+                for l in persisted_lists:
+                    db.session.delete(l)
+
+                # Then delete this board
                 db.session.delete(record)
 
     def _create_boards(self, fetched_boards, persisted_boards):


### PR DESCRIPTION
### What does this PR do?
Added logic: before deleting outdated boards from the database, delete the lists that refer to these board_ids.

### Motivation
The release command `python manage.py deploy` failed with `sqlalchemy.exc.IntegrityError`, which was caused by deleting records from the boards table without first deleting records of the lists with a foreign key reference to these boards. This also causes similar errors to be thrown after clicking the "refresh boards" button.

### Original Error Message
    sqlalchemy.exc.IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
    (psycopg2.errors.NotNullViolation) null value in column "board_id" violates not-null constraint
    DETAIL:  Failing row contains (966, WHAT IS HAPPENING HERE, 5c90ee025afe0d11211a48e5, 2019-03-19 14:11:36.415724, null).
    [SQL: UPDATE lists SET board_id=%(board_id)s WHERE lists.id = %(lists_id)s]
    [parameters: ({'board_id': None, 'lists_id': 966}, {'board_id': None, 'lists_id': 969}, {'board_id': None, 'lists_id': 972}, {'board_id': None, 'lists_id': 973}, {'board_id': None, 'lists_id': 999})]
    (Background on this error at: http://sqlalche.me/e/gkpj)

