### PR TITLE
Update `Trello_member_id` for existing Trello members

### DIFF
--- a/app/services/trello_member_service.py
+++ b/app/services/trello_member_service.py
@@ -56,6 +56,7 @@ class TrelloMemberService(APIService):
             None
         """
         fetched_member_ids = list(map(lambda x: x.id, fetched_members))
+        fetched_usernames = list(map(lambda x: x.username, fetched_members))
 
         for record in persisted_members:
             if record.trello_member_id in fetched_member_ids:
@@ -70,6 +71,20 @@ class TrelloMemberService(APIService):
                 # Update the attributes
                 record.name = trello_member.full_name
                 record.username = trello_member.username
+
+            elif record.username in fetched_usernames:
+                # In case `trello_member_id` changed for an existing `username`
+                trello_member = list(
+                    filter(
+                        lambda x: x.username == record.username,
+                        fetched_members
+                    )
+                )[0]
+
+                # Update the attributes
+                record.name = trello_member.full_name
+                record.trello_member_id = trello_member.id
+
             else:
                 db.session.delete(record)
 

--- a/tests/services/test_trello_member_service.py
+++ b/tests/services/test_trello_member_service.py
@@ -78,7 +78,6 @@ class TrelloMemberServiceTestCase(BaseTestCase):
         self.assertTrue(updated.name == 'Trello Name_0')
         self.assertTrue(updated.username == 'trello_member_0')
 
-    # FIXME: change update username to update memberid
     @patch('app.services.TrelloMemberService.__init__', new=PatchClass.__init__)
     def test_fetch_with_updated_member_id(self):
         """

--- a/tests/services/test_trello_member_service.py
+++ b/tests/services/test_trello_member_service.py
@@ -46,9 +46,9 @@ class TrelloMemberServiceTestCase(BaseTestCase):
         self.assertTrue(len(updated_trello_members) is 3)
 
     @patch('app.services.TrelloMemberService.__init__', new=PatchClass.__init__)
-    def test_fetch_with_update(self):
+    def test_fetch_with_updated_username(self):
         """
-        Tests the 'fetch' method, and validates it updates the trello_members
+        Tests the 'fetch' method, and validates it updates Trello username
         correctly.
         """
         trello_member_id = "some_uuid_0"
@@ -77,3 +77,37 @@ class TrelloMemberServiceTestCase(BaseTestCase):
         ).first()
         self.assertTrue(updated.name == 'Trello Name_0')
         self.assertTrue(updated.username == 'trello_member_0')
+
+    # FIXME: change update username to update memberid
+    @patch('app.services.TrelloMemberService.__init__', new=PatchClass.__init__)
+    def test_fetch_with_updated_member_id(self):
+        """
+        Tests the 'fetch' method, and validates it updates Trello member ID
+        correctly.
+        """
+        trello_username = 'trello_member_0'
+        trello_member_model = TrelloMember(
+            name='Old Name',
+            username=trello_username,
+            trello_member_id='some_uuid_old'
+        )
+        db.session.add(trello_member_model)
+
+        trello_member_service = TrelloMemberService()
+
+        # Validate record has proper attributes
+        trello_member = TrelloMember.query.filter_by(
+            username=trello_username
+        ).first()
+        self.assertTrue(trello_member.name == 'Old Name')
+        self.assertTrue(trello_member.trello_member_id == 'some_uuid_old')
+
+        # Fetch and insert the trello_members into the database
+        trello_member_service.fetch()
+
+        # Validate record attributes have been updated
+        updated = TrelloMember.query.filter_by(
+            username=trello_username
+        ).first()
+        self.assertTrue(updated.name == 'Trello Name_0')
+        self.assertTrue(updated.trello_member_id == 'some_uuid_0')


### PR DESCRIPTION
### What does this PR do?
When a user clicks on `Refresh Trello Members`, a condition is implemented to check for updated `Trello_member_id` for existing users (with unchanged `username`), and commit the change accordingly.

### Motivation
A fetch for Trello members failed with: `sqlalchemy.exc.IntegrityError` due to a change in `trello_member_id` for an existing user. 

Because both `trello_member_id` and `username` are subject to change (despite being unique identifiers), this PR aims to cross-reference them to keep track of such changes.


### Original Error Message
```
  2019-07-22T21:55:14.151715+00:00 app[web.1]: cursor.execute(statement, parameters)
  2019-07-22T21:55:14.151719+00:00 app[web.1]: sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "ix_trello_members_username"
  2019-07-22T21:55:14.151721+00:00 app[web.1]: DETAIL:  Key (username)=(some_user) already exists.
  2019-07-22T21:55:14.151723+00:00 app[web.1]: 
  2019-07-22T21:55:14.151726+00:00 app[web.1]: [SQL: INSERT INTO trello_members (name, username, trello_member_id, timestamp) VALUES (%(name)s, %(username)s, %(trello_member_id)s, %(timestamp)s) RETURNING trello_members.id]
  2019-07-22T21:55:14.151729+00:00 app[web.1]: [parameters: {'name': 'Some User', 'username': 'some_user', 'trello_member_id': 'new-trello-member-id', 'timestamp': datetime.datetime(some-timestamp)}]
  2019-07-22T21:55:14.151731+00:00 app[web.1]: (Background on this error at: http://sqlalche.me/e/gkpj)
  2019-07-22T21:55:14.151988+00:00 app[web.1]: 10.37.201.103 - - [22/Jul/2019:21:55:14 +0000] "POST /trello_members/ HTTP/1.1" 500 0 "-" "-"
```
