### PR TITLE
Removed the `list_ids` to improve UX for creating a subscription.

### DIFF
--- a/app/controllers/subscribed_lists/views.py
+++ b/app/controllers/subscribed_lists/views.py
@@ -49,7 +49,7 @@ def index(board_id, repo_id):
             trello_member_id=member_id
         )
 
-        flash('Created subscription')
+        flash('Created subscribed list')
         return redirect(url_for('.index', board_id=board_id, repo_id=repo_id))
     elif request.method == 'POST':
         flash(
@@ -106,7 +106,7 @@ def update(board_id, repo_id, list_id):
             trello_member_id=member_id
         )
 
-        flash('Updated subscription')
+        flash('Updated subscribed list')
         return redirect(url_for('.index', board_id=board_id, repo_id=repo_id))
     else:
         flash(
@@ -127,5 +127,5 @@ def update(board_id, repo_id, list_id):
 @login_required
 def delete(board_id, repo_id, list_id):
     subscribed_list_service.delete(board_id, repo_id, list_id)
-    flash('Deleted subscription')
+    flash('Deleted subscribed list')
     return redirect(url_for('.index', board_id=board_id, repo_id=repo_id))

--- a/app/controllers/subscriptions/forms.py
+++ b/app/controllers/subscriptions/forms.py
@@ -21,7 +21,7 @@ import textwrap
 from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField, SubmitField
 from wtforms.validators import Required, Length
-from ...models import Board, List, Repo, Subscription
+from ...models import Board, Repo, Subscription
 
 
 class NewSubscriptionForm(FlaskForm):
@@ -42,16 +42,6 @@ class NewSubscriptionForm(FlaskForm):
             """
             The name of a GitHub repository you wish to register event webhooks
             for
-            """
-        )
-    )
-    list_ids = StringField(
-        'List IDs',
-        description=textwrap.dedent(
-            """
-            A comma delimited list of <code>List.trello_list_id</code>s
-            belonging to the <code>Board</code> associated with the
-            <code>board_id</code> above
             """
         )
     )
@@ -84,12 +74,9 @@ class NewSubscriptionForm(FlaskForm):
 
         - Validates the `board_id `attribute belongs to a `Board`
         - Validates the `repo_id `attribute belongs to a `Repo`
-        - Validates the `list_ids` attribute is a comma-delimited list of
-          `List.trello_list_id` belonging to the `Board` with `board_id`.
         """
         board_name = self.board_name.data.strip()
         repo_name = self.repo_name.data.strip()
-        ids = self.list_ids.data.strip()
 
         # Perform board-specific validations
         board = Board.query.filter_by(name=board_name).first()
@@ -123,27 +110,6 @@ class NewSubscriptionForm(FlaskForm):
             self._error_message = textwrap.dedent(
                 f"""
                 Subscription exists for {board_name} and {repo_name}
-                """
-            )
-            return False
-
-        # If the field is empty, return `True`
-        if not ids:
-            return True
-
-        ids_list = re.split("\s*,\s*", ids)
-
-        # Validate all list id are valid `List`s associated to the `board_id`
-        valid_list_ids = all(
-            List.query.filter_by(
-                trello_list_id=list_id, board_id=self._board_id
-            ) is not None for list_id in ids_list
-        )
-
-        if not valid_list_ids:
-            self._error_message = textwrap.dedent(
-                f"""
-                The `list_ids` passed in are not valid
                 """
             )
             return False

--- a/app/controllers/subscriptions/views.py
+++ b/app/controllers/subscriptions/views.py
@@ -36,8 +36,6 @@ def create():
     create_form = NewSubscriptionForm(request.form)
 
     if create_form.validate():
-        ids = create_form.list_ids.data
-        list_ids = re.split("\s*,\s*", ids.strip()) if ids else []
         repo_id = create_form.get_repo_id()
 
         # check if there already exists a webhook with this repository
@@ -53,8 +51,7 @@ def create():
             board_id=create_form.get_board_id(),
             repo_id=repo_id,
             issue_autocard=create_form.issue_autocard.data,
-            pull_request_autocard=create_form.pull_request_autocard.data,
-            list_ids=list_ids
+            pull_request_autocard=create_form.pull_request_autocard.data
         )
         flash('Created subscription')
         return redirect(url_for('main.index'))

--- a/app/services/subscription_service.py
+++ b/app/services/subscription_service.py
@@ -31,8 +31,7 @@ class SubscriptionService(CRUDService):
         """Creates a new `subscribed_list_service` for the class."""
         self._subscribed_list_service = SubscribedListService()
 
-    def create(self, board_id, repo_id, issue_autocard, pull_request_autocard,
-               list_ids=[]):
+    def create(self, board_id, repo_id, issue_autocard, pull_request_autocard):
         """Creates and persists a new subscription record to the database.
 
         Args:
@@ -43,8 +42,6 @@ class SubscriptionService(CRUDService):
                 created.
             pull_request_autocard (Boolean): If `autocard` is `true` for Pull
                 Requests created.
-            list_ids (list(str)): An optional list of ids for trello lists to
-                associate to the subscription as `SubscribedList`s.
 
         Returns:
             None
@@ -56,16 +53,6 @@ class SubscriptionService(CRUDService):
             pull_request_autocard=pull_request_autocard
         )
         db.session.add(subscription)
-
-        # Create all the subscribed lists
-        for list_id in list_ids:
-            self._subscribed_list_service.create(
-                board_id=board_id,
-                repo_id=repo_id,
-                list_id=list_id
-            )
-
-        # Persists the subscription
         db.session.commit()
 
     def update(self, board_id, repo_id, issue_autocard, pull_request_autocard):


### PR DESCRIPTION
### What does this PR do?
Removed the `list_ids` field in the `Subscription` form to improve UX for creating a `Subscription` in the `/` view.

<img width="1176" alt="Screen Shot 2019-08-02 at 14 30 26" src="https://user-images.githubusercontent.com/8942499/62391186-22e5f980-b532-11e9-85e3-c30a2e1aca46.png">

### Motivation
I think it's currently bad UX to have the user enter a list of comma delimited hexadecimal IDs to create associated `SubscribedList`s for a `Subscription`. In this field there isn't currently autocomplete, so the user has to copy and paste list IDs to create these associated objects.

Since the user can create `SubscribedLists` in the `/subscriptions/lists/<board_id>/<repo_id>/` view, and there is field autocompletion for "List Name", I don' think it makes sense for us to keep this field.

<img width="1195" alt="Screen Shot 2019-08-02 at 14 31 53" src="https://user-images.githubusercontent.com/8942499/62391240-4f017a80-b532-11e9-93c7-7ac7972afde0.png">