### PR TITLE
Add repo-dependent label to Trello card

### DIFF
--- a/app/tasks/create_trello_card.py
+++ b/app/tasks/create_trello_card.py
@@ -26,7 +26,7 @@ class CreateTrelloCard(GitHubBaseTask):
         """Initializes a task to create a trello card."""
         self._trello_service = TrelloService()
 
-    def run(self, board_id, list_id, name, payload, assignee_id=None):
+    def run(self, board_id, list_id, name, payload, label_id=None, assignee_id=None):
         """Performs validations on the event type and enqueues them.
 
         Validates the event being received is a GitHub Pull Request event or a
@@ -39,6 +39,7 @@ class CreateTrelloCard(GitHubBaseTask):
             name (str): The name of the card.
             payload (dict): The card-specific data, used in the `_card_body`
                 template method.
+            label_id (str): The id of the repo-specific language label.
             assignee_id (str): The trello_member_id for the card assignee.
 
         Returns:
@@ -54,6 +55,7 @@ class CreateTrelloCard(GitHubBaseTask):
             list_id=list_id,
             name=name,
             desc=self._card_body(),
+            label_id=label_id,
             assignee_id=assignee_id
         )
         card.attach(self._title, url=self._url)

--- a/config.py
+++ b/config.py
@@ -32,6 +32,19 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SSL_DISABLE = False
 
+    # Note:
+    #   Before adding repo-label pair, please make sure label
+    #   (eg. 'Go') exists on respective Trello board
+    REPO_LABELS = {
+        'dd-trace-go': 'Go',
+        'dd-trace-php': 'PHP',
+        'dd-trace-py': 'Python',
+        'dd-trace-rb': 'Ruby',
+        'dd-trace-java': 'Java',
+        'dd-trace-js': 'JavaScript',
+        'dd-trace-dotnet': '.NET'
+    }
+
     @staticmethod
     def init_app(app):
         env_file_path = os.path.join(app.root_path, '../', '.env')


### PR DESCRIPTION
### What does this PR do?
During card creation, if its source GitHub repo is listed in `REPO_LABELS`, a (language) label would be attached to the new card (ex. an issue from repo `dd-trace-go` would result in a `Go` label in Trello).

### Motivation
Feature requested by APM team

### Additional Notes
New repo-label mappings can be added as key-value pairs in `REPO_LABELS` in `config.py`.
Note that this is board-agnostic, but please make sure the label name already exists in target Trello boards (new Trello labels would not be created by Gello).

Due to time constraints, the `REPO_LABELS` mapping currently exists as a dictionary in `config.py`, but going forward it would be good to store the repository-to-label relations in a database table, as well as name-to-ID mapping for labels per Trello board. 