### PR TITLE
[apm] add CPP label to `dd-opentracing-cpp`

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,8 @@ class Config:
         'dd-trace-rb': 'Ruby',
         'dd-trace-java': 'Java',
         'dd-trace-js': 'JavaScript',
-        'dd-trace-dotnet': '.NET'
+        'dd-trace-dotnet': '.NET',
+        'dd-opentracing-cpp': 'CPP',
     }
 
     @staticmethod


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Gello Contribution Guidelines if you have not yet done so.* -->

### What does this PR do?

Updates `REPO_LABELS` so that `dd-opentracing-cpp` repository includes `CPP` label.

### Motivation

Add a new repository with labels.

### Additional Notes

None.
