### PR TITLE
Make dev constraint name match the prod constraint name.

### DIFF
--- a/migrations/versions/1d125da81dbf_introduce_jira_models.py
+++ b/migrations/versions/1d125da81dbf_introduce_jira_models.py
@@ -37,7 +37,7 @@ def upgrade():
             autoincrement=True
         )
     )
-    op.drop_constraint('subscribed_lists_subscription_board_id_subscription_repo_id_fkey',
+    op.drop_constraint('subscribed_lists_subscription_board_id_fkey',
                        'subscribed_lists', type_='foreignkey')
     op.add_column('subscriptions', sa.Column(
         'project_key', sa.String(length=64), nullable=True))
@@ -49,7 +49,7 @@ def upgrade():
     op.create_unique_constraint('subscriptions_board_id_key', 'subscriptions', ['board_id', 'repo_id'])
     op.create_unique_constraint('subscriptions_project_key_key', 'subscriptions', ['project_key', 'repo_id'])
 
-    op.create_foreign_key('subscribed_lists_subscription_board_id_subscription_repo_id_fkey', 'subscribed_lists', 'subscriptions', [
+    op.create_foreign_key('subscribed_lists_subscription_board_id_fkey', 'subscribed_lists', 'subscriptions', [
                           'subscription_board_id', 'subscription_repo_id'], ['board_id', 'repo_id'])
     op.create_table('jira_issue_types',
                     sa.Column('id', sa.Integer(), nullable=False),
@@ -228,7 +228,7 @@ def downgrade():
     op.drop_index(op.f('ix_jira_issue_types_timestamp'),
                   table_name='jira_issue_types')
     op.drop_table('jira_issue_types')
-    op.drop_constraint('subscribed_lists_subscription_board_id_subscription_repo_id_fkey',
+    op.drop_constraint('subscribed_lists_subscription_board_id_fkey',
                        'subscribed_lists', type_='foreignkey')
     op.drop_constraint('subscriptions_project_key_key', 'subscriptions', type_='unique')
     op.drop_constraint('subscriptions_board_id_key', 'subscriptions', type_='unique')
@@ -238,7 +238,7 @@ def downgrade():
     op.drop_constraint('subscriptions_pkey', 'subscriptions', 'primary')
     op.create_primary_key('subscriptions_pkey', 'subscriptions', ["board_id", "repo_id", ])
     op.drop_column('subscriptions', 'project_key')
-    op.create_foreign_key('subscribed_lists_subscription_board_id_subscription_repo_id_fkey', 'subscribed_lists', 'subscriptions', [
+    op.create_foreign_key('subscribed_lists_subscription_board_id_fkey', 'subscribed_lists', 'subscriptions', [
                           'subscription_board_id', 'subscription_repo_id'], ['board_id', 'repo_id'])
     op.drop_column('subscriptions', 'id')
     op.execute(sa.schema.DropSequence(sa.Sequence("subscriptions_id_seq")))

--- a/migrations/versions/1d125da81dbf_introduce_jira_models.py
+++ b/migrations/versions/1d125da81dbf_introduce_jira_models.py
@@ -37,7 +37,7 @@ def upgrade():
             autoincrement=True
         )
     )
-    op.drop_constraint('subscribed_lists_subscription_board_id_subscription_repo_i_fkey',
+    op.drop_constraint('subscribed_lists_subscription_board_id_subscription_repo_id_fkey',
                        'subscribed_lists', type_='foreignkey')
     op.add_column('subscriptions', sa.Column(
         'project_key', sa.String(length=64), nullable=True))
@@ -49,7 +49,7 @@ def upgrade():
     op.create_unique_constraint('subscriptions_board_id_key', 'subscriptions', ['board_id', 'repo_id'])
     op.create_unique_constraint('subscriptions_project_key_key', 'subscriptions', ['project_key', 'repo_id'])
 
-    op.create_foreign_key('subscribed_lists_subscription_board_id_subscription_repo_i_fkey', 'subscribed_lists', 'subscriptions', [
+    op.create_foreign_key('subscribed_lists_subscription_board_id_subscription_repo_id_fkey', 'subscribed_lists', 'subscriptions', [
                           'subscription_board_id', 'subscription_repo_id'], ['board_id', 'repo_id'])
     op.create_table('jira_issue_types',
                     sa.Column('id', sa.Integer(), nullable=False),
@@ -228,7 +228,7 @@ def downgrade():
     op.drop_index(op.f('ix_jira_issue_types_timestamp'),
                   table_name='jira_issue_types')
     op.drop_table('jira_issue_types')
-    op.drop_constraint('subscribed_lists_subscription_board_id_subscription_repo_i_fkey',
+    op.drop_constraint('subscribed_lists_subscription_board_id_subscription_repo_id_fkey',
                        'subscribed_lists', type_='foreignkey')
     op.drop_constraint('subscriptions_project_key_key', 'subscriptions', type_='unique')
     op.drop_constraint('subscriptions_board_id_key', 'subscriptions', type_='unique')
@@ -238,7 +238,7 @@ def downgrade():
     op.drop_constraint('subscriptions_pkey', 'subscriptions', 'primary')
     op.create_primary_key('subscriptions_pkey', 'subscriptions', ["board_id", "repo_id", ])
     op.drop_column('subscriptions', 'project_key')
-    op.create_foreign_key('subscribed_lists_subscription_board_id_subscription_repo_i_fkey', 'subscribed_lists', 'subscriptions', [
+    op.create_foreign_key('subscribed_lists_subscription_board_id_subscription_repo_id_fkey', 'subscribed_lists', 'subscriptions', [
                           'subscription_board_id', 'subscription_repo_id'], ['board_id', 'repo_id'])
     op.drop_column('subscriptions', 'id')
     op.execute(sa.schema.DropSequence(sa.Sequence("subscriptions_id_seq")))

--- a/migrations/versions/4556966b899e_create_subscribed_lists_table.py
+++ b/migrations/versions/4556966b899e_create_subscribed_lists_table.py
@@ -34,7 +34,8 @@ def upgrade():
         sa.Column('timestamp', sa.DateTime(), nullable=True),
         sa.ForeignKeyConstraint(
             ['subscription_board_id', 'subscription_repo_id'],
-            ['subscriptions.board_id', 'subscriptions.repo_id']
+            ['subscriptions.board_id', 'subscriptions.repo_id'],
+            name='subscribed_lists_subscription_board_id_fkey'
         ),
         sa.ForeignKeyConstraint(['list_id'], ['lists.trello_list_id']),
         sa.PrimaryKeyConstraint(

--- a/migrations/versions/4556966b899e_create_subscribed_lists_table.py
+++ b/migrations/versions/4556966b899e_create_subscribed_lists_table.py
@@ -34,8 +34,7 @@ def upgrade():
         sa.Column('timestamp', sa.DateTime(), nullable=True),
         sa.ForeignKeyConstraint(
             ['subscription_board_id', 'subscription_repo_id'],
-            ['subscriptions.board_id', 'subscriptions.repo_id'],
-            name='subscribed_lists_subscription_board_id_subscription_repo_i_fkey'
+            ['subscriptions.board_id', 'subscriptions.repo_id']
         ),
         sa.ForeignKeyConstraint(['list_id'], ['lists.trello_list_id']),
         sa.PrimaryKeyConstraint(


### PR DESCRIPTION
### What does this PR do?

A [previous commit modified an already-run migration](https://github.com/DataDog/gello/blob/master/migrations/versions/4556966b899e_create_subscribed_lists_table.py#L38) to fix a name-length limit in postgres. However, turns out prod was using a different name `subscribed_lists_subscription_board_id_fkey`, which isn't mentioned in any of the migrations. This might have been a manual change or a difference in SQLAlchemy mangling in prod and dev. This PR makes the dev constraint name match prod.

Action Required: If you have a dev instance of Gello, you may want to recreate the database to have the newly named constraint from `subscribed_lists_subscription_board_id_subscription_repo_i_fkey ` to `subscribed_lists_subscription_board_id_fkey`, or you can modify it directly in pgAdmin.

### Motivation
Gello deploy was failing due to a migration error.

### Additional Notes
PostgreSQL's max identifier length is 63 bytes.
