### PR TITLE
Truncate issue summary; Added default value to get_hooks() to avoid exception (requires testing)

### DIFF
--- a/app/services/github_service.py
+++ b/app/services/github_service.py
@@ -98,7 +98,17 @@ class GitHubService(object):
         Returns:
             github.Hook.Hook: The Github organization webhook object with `url_root` as the url.
         """
-        for hook in self._get_organization().get_hooks():
+        # TODO(URSULA): Clean this up once Github Pagination API totalCount does not throw an exception
+        # (https://pygithub.readthedocs.io/en/latest/utilities.html#github.PaginatedList.PaginatedList)
+        try:
+            total_count = self._get_organization().get_hooks().totalCount
+        except UnknownObjectException as e:
+            print("github.GithubException.UnknownObjectException:", e)
+            total_count = 0
+        
+        hooks = self._get_organization().get_hooks() if total_count > 0 else []
+
+        for hook in hooks:
             if (hook.config['url'] == url_root or
                     (hook.config['url'][-1] != '/' and hook.config['url'] + "/" == url_root)):
                 return hook

--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -210,8 +210,9 @@ class ProjectService(APIService):
         )
 
         for jira_issue in jira_issues_to_create:
+            issue_summary = jira_issue.fields.summary if len(jira_issue.fields.summary) <= 64 else jira_issue.fields.summary[:61] + "..."
             jira_issue_model = JIRAParentIssue(
-                summary=jira_issue.fields.summary,
+                summary=issue_summary,
                 jira_issue_key=jira_issue.key,
                 project_key=project_key
             )
@@ -248,7 +249,7 @@ class ProjectService(APIService):
         Args:
             fetched_issues (list(JIRA.IssueType)): JIRA Issue Type objects to
                 be inserted into the database.
-            project_key (str): The key of the `Project` the issues types will
+            project (Project): The `Project` object where the issues types will
                 be associated to.
 
         Returns:


### PR DESCRIPTION
### What does this PR do?
This PR has 2 fixes.
Fix 1: Truncates jira parent issue summaries before entering into the database due to [this constraint](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/models/jira_parent_issue.py#L30).
Fix 2: Added default value to [JIRA API `get_hooks()` line](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/services/github_service.py#L103-L107) due to [Github API Pagination API's `totalCount`](https://pygithub.readthedocs.io/en/latest/utilities.html#github.PaginatedList.PaginatedList) not working consistently with webhooks.

### Motivation
Fix 1: [This line querying `project.issue_types`](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/services/project_service.py#L259) was breaking in prod. Suspecting [this previously executed line creating `JIRAParentIssue`](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/services/project_service.py#L214-L218) to be the cause. [Here](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/services/project_service.py#L160-L161) is their common ancestor function caller.
Fix 2: Unable to create github org webhooks in prod.

### Additional Notes
Fix 1: Could not recreate this bug in dev environment. Require further testing in prod.
Fix 2: Was able to recreate this bug in terminal and in dev environment. Require further testing in prod.
