### PR TITLE
Extracted fetching JIRA projects to avoid heroku worker timeouts

### DIFF
--- a/app/controllers/projects/views.py
+++ b/app/controllers/projects/views.py
@@ -21,9 +21,7 @@ from flask_login import login_required
 from . import project
 from .forms import RefreshForm
 from ...models import Project, ConfigValue
-from ...services import ProjectService
-
-project_service = ProjectService()
+from ...tasks.fetch_jira_projects import FetchJIRAProjects
 
 
 @project.route('/', methods=['GET', 'POST'])
@@ -38,8 +36,8 @@ def index():
 
     form = RefreshForm()
     if form.validate_on_submit():
-        project_service.fetch()
-        flash('The projects have been updated.')
+        FetchJIRAProjects.delay()
+        flash('The projects are being updated. This may take a couple of minutes. Please refresh page regularly. No need to click the refresh button.')
 
         return redirect(url_for('.index'))
 

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -36,6 +36,7 @@ from .update_jira_issue_labels import UpdateJiraIssueLabels
 from .update_pull_request_card_labels import UpdatePullRequestCardLabels
 from .update_jira_pull_request_issue_labels import UpdateJiraPullRequestIssueLabels
 from .github_receiver import GitHubReceiver
+from .fetch_jira_projects import FetchJIRAProjects
 
 
 def _register_tasks():
@@ -59,5 +60,6 @@ def _register_tasks():
     celery.tasks.register(UpdatePullRequestCardLabels())
     celery.tasks.register(UpdateJiraPullRequestIssueLabels())
     celery.tasks.register(GitHubReceiver())
+    celery.tasks.register(FetchJIRAProjects())
 
 _register_tasks()

--- a/app/tasks/fetch_jira_projects.py
+++ b/app/tasks/fetch_jira_projects.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""fetch_jira_projects.py
+
+Fetches JIRA projects.
+"""
+
+from celery.task import Task
+from ..services.project_service import ProjectService
+
+
+class FetchJIRAProjects(Task):
+    """A task to fetches JIRA projects."""
+
+    def __init__(self):
+        """Initializes a `FetchJIRAProjects` object for the class."""
+        pass
+
+    def run(self):
+        """Fetches JIRA projects.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+        ProjectService().fetch()


### PR DESCRIPTION
### What does this PR do?
Extract fetching JIRA projects into an async task to not freeze the frontend and avoid heroku worker timeouts.

### Motivation
Fetching large number of JIRA projects causes heroku worker timeouts.

### Additional Notes
Possible clean up: Find a better UX for informing the user that JIRA projects have been updated, currently using [flash](https://github.com/DataDog/gello/commit/26958b672f46ee6b54a8a45cae104b432de9cb95#diff-c70a76ab5c96642ee11efeaba9c96103R40).
