### PR TITLE
Adds rate limiting delays to large lazy-loaded paginated Github API calls

### DIFF
--- a/app/services/github_service.py
+++ b/app/services/github_service.py
@@ -16,6 +16,8 @@ Service-helpers for interacting with the GitHub API.
 """
 
 from os import environ
+import time
+
 from ..api_clients import GitHubAPIClient
 from ..models import ConfigValue
 from .config_value_service import ConfigValueService
@@ -44,6 +46,17 @@ class GitHubService(object):
             list(github.Member)
         """
         return self._get_organization().get_members()
+
+    def rate_limit_sleep(self):
+        """Sleep after making a request to Github API.
+        Adhering to Github's rate limit of 5000 requests per hour: https://developer.github.com/v3/#rate-limiting
+        Delay calculation: 5000 requests / 3600 seconds (in an hour) = 1.39.
+        Rounded up to 1.5 for buffer. Specifically, 5000*1.5-5000*1.39 = 550 more requests.
+
+        Returns:
+            None
+        """
+        time.sleep(1.5)
 
     def create_github_hook(self, url_root, repo_id):
         """Creates a repository webhook for a given repo.


### PR DESCRIPTION
### What does this PR do?
Adds rate limiting delays to large lazy-loaded paginated Github API calls to adhere to [Github's rate limit of 5000 requests per hour](https://developer.github.com/v3/#rate-limiting).

### Motivation
`github.GithubException.RateLimitExceededException` raised in heroku release due to lazy loading of a large number of github repos.

### Additional Notes
Did not add rate limiting delays to requests fetching Github organizations in [`onboarding.py`](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/api/onboarding.py#L48-L54), [`onboarding/forms.py`](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/controllers/onboarding/forms.py#L85-L86), [`onboarding/views.py`](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/controllers/onboarding/views.py#L102), and [`github_service.py`](https://github.com/ursulahuang/gello/blob/ursula_huang_auto_refresh_members_and_add_labels_to_issue_cards/app/services/github_service.py#L192-L195). It is assumed that list of Github organizations will not be larger than the [default page size of 30](https://github.com/PyGithub/PyGithub/blob/master/github/PaginatedList.py#L142-L143).
