### PR TITLE
Catch Celery tasks that modify db with a rollback

### DIFF
--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -249,7 +249,7 @@ class ProjectService(APIService):
         Args:
             fetched_issues (list(JIRA.IssueType)): JIRA Issue Type objects to
                 be inserted into the database.
-            project (Project): The `Project` object where the issues types will
+            project_key (str): The key of the `Project` the issues types will
                 be associated to.
 
         Returns:

--- a/app/tasks/create_github_webhook.py
+++ b/app/tasks/create_github_webhook.py
@@ -15,12 +15,12 @@
 Creates a webhook for a repository.
 """
 
-from celery.task import Task
+from .db_task import DBTask
 from ..services import GitHubService
 from ..services import RepoService
 
 
-class CreateGitHubWebhook(Task):
+class CreateGitHubWebhook(DBTask):
     """A task to create a GitHub Repo Webhook."""
 
     def __init__(self):

--- a/app/tasks/db_task.py
+++ b/app/tasks/db_task.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""db_task.py
+
+Abstract db base class for tasks.
+"""
+
+from celery.task import Task
+from .. import db
+
+
+class DBTask(Task):
+    """An abstract base class for database-related tasks."""
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        db.session.rollback()
+        super().on_failure(exc, task_id, args, kwargs, einfo)
+
+    def run(self):
+        """Implement in concretion."""
+        raise NotImplementedError()

--- a/app/tasks/delete_github_webhook.py
+++ b/app/tasks/delete_github_webhook.py
@@ -15,12 +15,12 @@
 Deletes a webhook from a repository.
 """
 
-from celery.task import Task
+from .db_task import DBTask
 from ..services import GitHubService
 from ..services import RepoService
 
 
-class DeleteGitHubWebhook(Task):
+class DeleteGitHubWebhook(DBTask):
     """A task to delete an existing GitHub Webhook."""
 
     def __init__(self):
@@ -38,25 +38,7 @@ class DeleteGitHubWebhook(Task):
         Returns:
             None
         """
-
-        # Delete a GitHub webhook on given repo
-        self._github_service.delete_github_hook(
-            webhook_id=webhook_id,
-            repo_id=repo_id
-        )
+        self._github_service.delete_github_hook(webhook_id=webhook_id, repo_id=repo_id)
 
         # Reset the webhook_id field to None in repo record in database
-        self._delete_webhook_from_database(repo_id=repo_id)
-
-    def _delete_webhook_from_database(self, repo_id):
-        """Concrete helper method.
-
-        Internal helper to remove the github_webhook_id field from specified record.
-
-        Args:
-            repo_id (int): The id for the repo record to remove webhook id from.
-
-        Returns:
-            None
-        """
         self._repo_service.remove_webhook(repo_id=repo_id)

--- a/app/tasks/fetch_jira_projects.py
+++ b/app/tasks/fetch_jira_projects.py
@@ -15,11 +15,11 @@
 Fetches JIRA projects.
 """
 
-from celery.task import Task
+from .db_task import DBTask
 from ..services.project_service import ProjectService
 
 
-class FetchJIRAProjects(Task):
+class FetchJIRAProjects(DBTask):
     """A task to fetches JIRA projects."""
 
     def __init__(self):

--- a/app/tasks/github_base_task.py
+++ b/app/tasks/github_base_task.py
@@ -15,10 +15,10 @@
 Abstract base class for tasks.
 """
 
-from celery.task import Task
+from .db_task import DBTask
 
 
-class GitHubBaseTask(Task):
+class GitHubBaseTask(DBTask):
     """An abstract base class for GitHub-related tasks."""
 
     def run(self):

--- a/app/tasks/upsert_github_org_webhook.py
+++ b/app/tasks/upsert_github_org_webhook.py
@@ -17,13 +17,13 @@ Updates or creates a webhook for an organization.
 
 from os import environ
 
-from celery.task import Task
+from .db_task import DBTask
 from ..models import ConfigValue
 from ..services.github_service import GitHubService
 from ..services.environment_variable_service import EnvironmentVariableService
 
 
-class UpsertGitHubOrgWebhook(Task):
+class UpsertGitHubOrgWebhook(DBTask):
     """A task to update or create a GitHub Organization Webhook."""
 
     def __init__(self):


### PR DESCRIPTION
### What does this PR do?
If an exception occurs in a Celery task, the changes in the transaction do not get rolled back. 

### Motivation
Currently, when an exception occurs in a Celery task, nothing catches that exception and rolls back the transaction, so any subsequent Celery tasks will be poisoned with the same exception.

### Additional Notes
When an exception occurs in the web process, Flask SQLAlchemy does the rollback for you. However, Celery tasks are on a worker process rather than the web process, so the transaction never gets rolled back.
