### PR TITLE
Truncated jira parent issue summary in updating function.

### DIFF
--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -181,7 +181,8 @@ class ProjectService(APIService):
                 jira_issue = fetched_issue_dict[record.jira_issue_key]
 
                 # Update the attributes
-                record.summary = jira_issue.fields.summary
+                issue_summary = jira_issue.fields.summary if len(jira_issue.fields.summary) <= 64 else jira_issue.fields.summary[:61] + "..."  # Truncate issue due to table constraint
+                record.summary = issue_summary
                 record.jira_issue_key = jira_issue.key
             else:
                 db.session.delete(record)


### PR DESCRIPTION
### What does this PR do?
Follow-up PR to [this PR that helped debug](https://github.com/DataDog/gello/pull/112) the exception and [this PR](https://github.com/DataDog/gello/pull/108) that truncated summaries before creating the SQLAlchemy object. This PR covers a missed case.

### Motivation
The exception `psycopg2.errors.StringDataRightTruncation: value too long for type character varying(64)` is preventing the task from finishing its function of updating and adding JIRA projects.

