### PR TITLE
Drop explicit return for Jira Card Creation

### DIFF
--- a/app/tasks/create_jira_issue.py
+++ b/app/tasks/create_jira_issue.py
@@ -69,8 +69,7 @@ class CreateJIRAIssue(GitHubBaseTask):
             self._persist_issue_to_database(issue=issue)
 
         except JIRAError as err:
-            print(err)
-            return err
+            print('JIRAError Returned: {0}'.format(err))
 
     def jira_service(self):
         """Returns the JiraService instance.


### PR DESCRIPTION
### What does this PR do?

Removes a return and enhances the printing of the JIRA API error

### Motivation

A very difficult to trace error when a JIRA issue does not get created correctly

### Additional Notes

This was introduced in 4fd0c822769ea65d05ef25276e2da9be2b913f77 which was a very large change set and altered the contract of no return value. For now I have made it print, but if we want to record or bubble up these errors in a different way it can be re-factored.
