### PR TITLE
Ask/increase jira member limit

### DIFF
--- a/app/services/jira_service.py
+++ b/app/services/jira_service.py
@@ -76,7 +76,7 @@ class JIRAService(object):
         """
         if self._init_if_needed():
             return self.client.search_assignable_users_for_projects(
-                '', project_key)
+                '', project_key, 0, 5000)
 
     def _convert_into_snake_case(self, words):
         return "_".join(words.split(" "))

--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -89,9 +89,9 @@ class ProjectService(APIService):
                     else:
                         persisted_users.pop(user)
 
-                for user in persisted_users:
-                    if user.jira_member_id not in fetched_user_ids:
-                        record.allowed_members.remove(user)
+                for user_id, user_object in persisted_users.items():
+                    if user_id not in fetched_user_ids:
+                        record.allowed_members.remove(user_object)
 
                 # Update the attributes
                 record.name = jira_proj.name


### PR DESCRIPTION
### What does this PR do?
The previous configuration used the default for querying users from JIRA of 50. https://jira.readthedocs.io/en/master/api.html#jira.JIRA.search_assignable_users_for_projects To support our larger organization, I've bumped this to 5000.

It also fixes an issue where users removed from a JIRA project were not being correctly removed from the JIRA project in the Gello database.

### Motivation
An error led me to debug this and found the two issues:
![image](https://user-images.githubusercontent.com/67006865/117093459-faa2b480-ad2e-11eb-8970-a24da3f08add.png)
