### PR TITLE
add label github_closed to issue when closing

### DIFF
--- a/app/services/jira_service.py
+++ b/app/services/jira_service.py
@@ -143,3 +143,11 @@ class JIRAService(object):
             '"')
         issue = issues[0]
         issue.update(fields={"labels": label_names})
+
+    def append_issue_labels(self, project_key, issue_key, label_names):
+        issues = self.client.search_issues(
+            'project = "' + project_key +
+            '" AND issuekey = "' + issue_key +
+            '"')
+        issue = issues[0]
+        issue.update(labels=[{"add": self._convert_into_snake_case(label)} for label in label_names])

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -37,6 +37,8 @@ from .update_pull_request_card_labels import UpdatePullRequestCardLabels
 from .update_jira_pull_request_issue_labels import UpdateJiraPullRequestIssueLabels
 from .github_receiver import GitHubReceiver
 from .fetch_jira_projects import FetchJIRAProjects
+from .append_jira_issue_labels import AppendJiraIssueLabels
+from .append_jira_pull_request_issue_labels import AppendJiraPullRequestIssueLabels
 
 
 def _register_tasks():
@@ -61,5 +63,7 @@ def _register_tasks():
     celery.tasks.register(UpdateJiraPullRequestIssueLabels())
     celery.tasks.register(GitHubReceiver())
     celery.tasks.register(FetchJIRAProjects())
+    celery.tasks.register(AppendJiraIssueLabels())
+    celery.tasks.register(AppendJiraPullRequestIssueLabels())
 
 _register_tasks()

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -35,11 +35,10 @@ from .update_issue_card_labels import UpdateIssueCardLabels
 from .update_jira_issue_labels import UpdateJiraIssueLabels
 from .update_pull_request_card_labels import UpdatePullRequestCardLabels
 from .update_jira_pull_request_issue_labels import UpdateJiraPullRequestIssueLabels
-from .github_receiver import GitHubReceiver
-from .fetch_jira_projects import FetchJIRAProjects
 from .append_jira_issue_labels import AppendJiraIssueLabels
 from .append_jira_pull_request_issue_labels import AppendJiraPullRequestIssueLabels
-
+from .github_receiver import GitHubReceiver
+from .fetch_jira_projects import FetchJIRAProjects
 
 def _register_tasks():
     """Registers class based celery tasks with celery worker."""

--- a/app/tasks/append_jira_issue_labels.py
+++ b/app/tasks/append_jira_issue_labels.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""append_jira_issue_labels.py
+
+Append labels tp a jira issue without overwriting already present labels.
+"""
+
+from . import GitHubBaseTask
+from ..services import JIRAService
+from ..models import Issue
+
+
+class AppendJiraIssueLabels(GitHubBaseTask):
+    """A class that updates the labels of a jira issue in a project."""
+
+    def __init__(self):
+        """Initializes a task to update the labels of a jira issue."""
+        self._jira_service = JIRAService()
+
+    def run(self, issue_id, project_key, label_names, payload):
+        """Call the JIRA client to append lables to the issue
+
+        Args:
+            issue_id (str): The id of the Github issue.
+            project_key (str): The key of the project to raise an issue on.
+            label_names (List[str]): A list of label names.
+            payload (dict): Github data specific to the JIRA issue to be updated.
+
+        Returns:
+            None
+        """
+        self.payload = payload
+        self.set_scope_data()
+        issue = Issue.query.filter_by(jira_project_key=project_key, github_issue_id=issue_id).first()
+        self._jira_service.append_issue_labels(project_key=project_key, issue_key=issue.jira_issue_key, label_names=label_names)

--- a/app/tasks/append_jira_pull_request_issue_labels.py
+++ b/app/tasks/append_jira_pull_request_issue_labels.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""update_jira_pull_request_issue_labels.py
+
+Updates a jira issue labels based on GitHub pull request data.
+"""
+
+from . import GitHubBaseTask
+from ..services import JIRAService
+from ..models import PullRequest
+
+
+class AppendJiraPullRequestIssueLabels(GitHubBaseTask):
+    """A class that updates the labels of a jira issue in a project."""
+
+    def __init__(self):
+        """Initializes a task to update the labels of a jira issue."""
+        self._jira_service = JIRAService()
+
+    def run(self, pull_request_id, project_key, label_names, payload):
+        """Call the JIRA client to append lables to the issue
+
+        Args:
+            pull_request_id (str): The id of the Github pull request.
+            project_key (str): The key of the project to raise an issue on.
+            label_names (List[str]): A list of label names.
+            payload (dict): Github data specific to the JIRA issue to be updated.
+
+        Returns:
+            None
+        """
+        self.payload = payload
+        self.set_scope_data()
+        pull_request = PullRequest.query.filter_by(jira_project_key=project_key, github_pull_request_id=pull_request_id).first()
+        self._jira_service.append_issue_labels(project_key=project_key, issue_key=pull_request.jira_issue_key, label_names=label_names)

--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -199,7 +199,7 @@ class GitHubReceiver(GitHubBaseTask):
                 self._update_pull_request_jira_issue_labels(self.payload['pull_request']['id'], project_key, label_names)
             elif action == 'closed':
                 AppendJiraPullRequestIssueLabels.delay(
-                    self.payload["issue"]["id"],
+                    self.payload["pull_request"]["id"],
                     project_key,
                     ["github_closed"],
                     self.payload,

--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -29,6 +29,8 @@ from . import UpdateIssueCardLabels
 from . import UpdateJiraIssueLabels
 from . import UpdateJiraPullRequestIssueLabels
 from . import UpdatePullRequestCardLabels
+from . import AppendJiraIssueLabels
+from . import AppendJiraPullRequestIssueLabels
 from ..models import ConfigValue
 from ..models import GitHubMember
 from ..models import Issue
@@ -171,6 +173,12 @@ class GitHubReceiver(GitHubBaseTask):
             elif action == "labeled" or action == "unlabeled":
                 self._update_issue_jira_issue_labels(self.payload['issue']['id'], project_key, label_names)
             elif action == 'closed':
+                AppendJiraIssueLabels.delay(
+                    self.payload["issue"]["id"],
+                    project_key,
+                    ["github_closed"],
+                    self.payload,
+                )
                 self._delete_issue_jira_issue_objects()
             else:
                 print('Unsupported event action: {0}'.format(action))
@@ -190,6 +198,12 @@ class GitHubReceiver(GitHubBaseTask):
             elif action == "labeled" or action == "unlabeled":
                 self._update_pull_request_jira_issue_labels(self.payload['pull_request']['id'], project_key, label_names)
             elif action == 'closed':
+                AppendJiraPullRequestIssueLabels.delay(
+                    self.payload["issue"]["id"],
+                    project_key,
+                    ["github_closed"],
+                    self.payload,
+                )
                 self._delete_pull_request_jira_issue_objects()
             else:
                 print('Unsupported event action.')


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Gello Contribution Guidelines if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
This PR adds a way to append labels to jira issues instead of overwriting them, and uses this to add the label `github_closed` to jira issues when the associated issue or PR is closed.

### Motivation
<!-- What inspired you to submit this pull request?-->
This would allow to use JIRA automation to automatically move issues to the `Done`, or `Closed` column when the github source of the issue is closed, while not impacting other users not interested in this feature 

### Additional Notes
<!-- Anything else we should know when reviewing?-->
