### PR TITLE
delete PRs by id instead of by github PR id

### DIFF
--- a/app/services/pull_request_service.py
+++ b/app/services/pull_request_service.py
@@ -109,10 +109,10 @@ class PullRequestService(CRUDService):
         db.session.commit()
 
     def delete_by_id(self, pull_request_id):
-        """Deletes an old, persisted pull_request.
+        """Deletes an old, persisted pull_request by id.
 
         Args:
-            github_pull_request_id (int): The id of the GitHub pull request.
+            pull_request_id (int): The db id of the pull request.
 
         Returns:
             None

--- a/app/services/pull_request_service.py
+++ b/app/services/pull_request_service.py
@@ -107,3 +107,16 @@ class PullRequestService(CRUDService):
         PullRequest.query.filter_by(
                github_pull_request_id=github_pull_request_id).delete()
         db.session.commit()
+
+    def delete_by_id(self, pull_request_id):
+        """Deletes an old, persisted pull_request.
+
+        Args:
+            github_pull_request_id (int): The id of the GitHub pull request.
+
+        Returns:
+            None
+        """
+        PullRequest.query.filter_by(
+               id=pull_request_id).delete()
+        db.session.commit()

--- a/app/tasks/delete_trello_card.py
+++ b/app/tasks/delete_trello_card.py
@@ -27,7 +27,7 @@ class DeleteCardObjectFromDatabase(GitHubBaseTask):
         self._issue_service = IssueService()
         self._pull_request_service = PullRequestService()
 
-    def run(self, scope, github_id):
+    def run(self, scope, github_id, pull_request_id=None):
         """Deletes the record of the trello card in Gello.
 
         NOTE: this does not delete the card on the Trello board, only removes
@@ -44,6 +44,9 @@ class DeleteCardObjectFromDatabase(GitHubBaseTask):
         if scope == 'issue':
             self._issue_service.delete(github_issue_id=github_id)
         elif scope == 'pull_request':
-            self._pull_request_service.delete(github_pull_request_id=github_id)
+            if pull_request_id:
+                self._pull_request_service.delete_by_id(pull_request_id=pull_request_id)
+            else:
+                self._pull_request_service.delete(github_pull_request_id=github_id)
         else:
             print('Unsupported GitHub scope')

--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -589,7 +589,8 @@ class GitHubReceiver(GitHubBaseTask):
             if pull_request.jira_issue_key is None:
                 DeleteCardObjectFromDatabase.delay(
                     scope=scope,
-                    github_id=github_id
+                    github_id=None,
+                    pull_request_id=pull_request.id
                 )
 
     def _user_in_organization(self):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Gello Contribution Guidelines if you have not yet done so.* -->

### What does this PR do?
When deleting PR records from the DB, only delete the one associated with the current ID (instead of all associated with the github PR id).

### Motivation
We were deleting items we shouldn't be.