### PR TITLE
chore: add guard against null issue key; update foreign key to cascade

### DIFF
--- a/app/tasks/github_receiver.py
+++ b/app/tasks/github_receiver.py
@@ -204,14 +204,15 @@ class GitHubReceiver(GitHubBaseTask):
                 self._update_pull_request_jira_issue_labels(self.payload['pull_request']['id'], project_key, label_names)
             elif action == 'closed':
                 pull_request = PullRequest.query.filter_by(jira_project_key=project_key, github_pull_request_id=self.payload["pull_request"]["id"]).first()
-                jira_issue_key = pull_request.jira_issue_key
-                AppendJiraPullRequestIssueLabels.delay(
-                    jira_issue_key,
-                    project_key,
-                    ["github_closed"],
-                    self.payload,
-                )
-                self._delete_pull_request_jira_issue_objects()
+                if pull_request.jira_issue_key is not None:
+                    jira_issue_key = pull_request.jira_issue_key
+                    AppendJiraPullRequestIssueLabels.delay(
+                        jira_issue_key,
+                        project_key,
+                        ["github_closed"],
+                        self.payload,
+                    )
+                    self._delete_pull_request_jira_issue_objects()
             else:
                 print('Unsupported event action.')
         else:

--- a/migrations/versions/7b85146aad79_cascade_delete_for_issues_project_key_.py
+++ b/migrations/versions/7b85146aad79_cascade_delete_for_issues_project_key_.py
@@ -1,0 +1,54 @@
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache 2 License.
+#
+# This product includes software developed at Datadog
+# (https://www.datadoghq.com/).
+#
+# Copyright 2018 Datadog, Inc.
+#
+
+"""cascade delete for issues project_key foreign key
+
+Revision ID: 7b85146aad79
+Revises: 1d125da81dbf
+Create Date: 2022-11-21 18:38:32.240352
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '7b85146aad79'
+down_revision = '1d125da81dbf'
+
+
+def upgrade():
+    op.drop_constraint(constraint_name="issues_jira_project_key_fkey", table_name="issues", type_="foreignkey")
+
+    op.create_foreign_key(
+        constraint_name="issues_jira_project_key_fkey",
+        source_table="issues",
+        referent_table="projects",
+        local_cols=["jira_project_key"],
+        remote_cols=["key"],
+        ondelete="CASCADE",
+        onupdate="CASCADE"
+    )
+
+    pass
+
+
+def downgrade():
+    op.drop_constraint(constraint_name="issues_jira_project_key_fkey", table_name="issues", type_="foreignkey")
+
+    op.create_foreign_key(
+        constraint_name="issues_jira_project_key_fkey",
+        source_table="issues",
+        referent_table="projects",
+        local_cols=["jira_project_key"],
+        remote_cols=["key"]
+    )
+
+    pass


### PR DESCRIPTION
This tests two avenues of trying to improve the errors that prevent the project sync from succeeding by resolving an issue that occurs when the Jira Issue Key is not present. It also adds a simple migration to test out a theory that a lack of cascading deletes with foreign keys is preventing some code paths from continuing to execute and reverting some Postgres transactions